### PR TITLE
优化luci-app-multiaccountdial 脚本路径、接口重启和状态监控功能

### DIFF
--- a/applications/luci-app-multiaccountdial/luasrc/controller/multiaccountdial.lua
+++ b/applications/luci-app-multiaccountdial/luasrc/controller/multiaccountdial.lua
@@ -12,28 +12,25 @@ function index()
 end
 
 function redial()
-	os.execute("killall -9 pppd")
+	os.execute("/usr/libexec/multiaccountdial/multi_account_dial redial")
 	os.execute("logger -t multiaccountdial redial")
 end
 
 
 function add_vwan()
-	os.execute("multi_account_dial add")
+	os.execute("/usr/libexec/multiaccountdial/multi_account_dial add")
 	os.execute("logger -t multiaccountdial add_vwan")
 end
 
 function del_vwan()
-	os.execute("multi_account_dial del")
+	os.execute("/usr/libexec/multiaccountdial/multi_account_dial del")
 	os.execute("logger -t multiaccountdial del_vwan")
 end
 
 function act_status()
 	local e = {}
-	local mwan3_status = luci.util.exec("mwan3 status")
-	e.num_online = 0
-	for _ in mwan3_status:gmatch("tracking is active") do
-		e.num_online = e.num_online + 1
-	end
+	local num_online = luci.util.exec("/usr/libexec/multiaccountdial/multi_account_dial count_online")
+	e.num_online = num_online
 	luci.http.prepare_content("application/json")
 	luci.http.write_json(e)
 end

--- a/applications/luci-app-multiaccountdial/root/usr/libexec/multiaccountdial/multi_account_dial
+++ b/applications/luci-app-multiaccountdial/root/usr/libexec/multiaccountdial/multi_account_dial
@@ -7,8 +7,8 @@ syncdial_num=2
 macvlan_index=0
 command=$1
 track_ip='119.29.29.29 www.baidu.com 114.114.114.114'
-add_mwan=$(uci get multiaccountdial.@base_setting[0].add_mwan)
-dial_num=$(uci get multiaccountdial.@base_setting[0].dial_num)
+add_mwan=$(uci -q get  multiaccountdial.@base_setting[0].add_mwan)
+dial_num=$(uci -q get  multiaccountdial.@base_setting[0].dial_num)
 if [ "$dial_num" != "" ]; then
     syncdial_num=$dial_num
 fi
@@ -90,6 +90,7 @@ set network.vwan$index.password=$password
 set network.vwan$index.metric=$metric
 set network.vwan$index.defaultroute=0
 set network.vwan$index.ipv6=0
+set network.vwan$index.scriptmark=1
 add_list firewall.@zone[1].network=vwan$index
 set dhcp.vwan$index=dhcp
 set dhcp.vwan$index.interface=vwan$index
@@ -153,6 +154,35 @@ do
 done
 }
 
+redial_if(){
+    local if_cfg=$1
+    uci -q get network.${if_cfg}.scriptmark && {
+        echo redial interface ${if_cfg}
+        ifdown $if_cfg
+        ifup $if_cfg
+    }   
+}
+
+redial_all(){
+    config_load network
+    config_foreach redial_if interface
+}
+
+count_if(){
+    local if_cfg=$1  
+    uci -q get network.${if_cfg}.scriptmark>/dev/null && {
+        local up=$(ifstatus ${if_cfg} |grep '"up": true,' |wc -l )
+        local down=$(ifstatus ${if_cfg} |grep '"up": false,' |wc -l )
+        if [ $up -eq 1 ];then online=${online}1;fi
+        if [ $down -eq 1 ];then offline=${offline}1;fi
+   }   
+}
+
+count_all(){
+    config_load network
+    config_foreach count_if interface
+}
+
 case $command in
     "add")
         add_vwan
@@ -165,6 +195,14 @@ case $command in
         uci commit network
         uci commit firewall
         uci commit mwan3
+        ;;
+    "redial")
+        redial_all
+        ;;
+    "count_online")
+        count_all
+        echo 在线:$(echo -e $online | wc -L)
+        echo 离线:$(echo -e $offline | wc -L)
         ;;
     *)
         echo "unknown command $command"


### PR DESCRIPTION
将脚本移动到规范的路径，新增在线和离线的监控
controller:修改了计算接口数量的方法，不再依赖mwan3，修改了重启接口的方法,以及使用绝对路径调用脚本。