### PR TITLE
refactor(luci-app-feishuvpn): 更新 FeishuVPN 安装脚本

### DIFF
--- a/applications/luci-app-feishuvpn/root/usr/libexec/istorec/feishuvpn.sh
+++ b/applications/luci-app-feishuvpn/root/usr/libexec/istorec/feishuvpn.sh
@@ -13,18 +13,18 @@ do_install() {
     exit 1
   fi
 
-  [ -z "$image_name" ] && image_name="registry.cn-qingdao.aliyuncs.com/feishuwg/p2p:v2.2"
+  [ -z "$image_name" ] && image_name="registry.cn-qingdao.aliyuncs.com/feishuwg/p2p:latest"
   echo "docker pull ${image_name}"
   docker pull ${image_name}
   docker rm -f feishuvpn
 
-  local cmd="docker run --restart=unless-stopped -d -h FeiShuVpnServer -v \"$config:/data/conf\" "
+  local cmd="docker run --restart=unless-stopped -d -h FeiShuVpnServer -v \"$config:/app/data\" "
 
   cmd="$cmd\
   --cap-add=ALL \
   --privileged=true \
   --device=/dev/net/tun \
-  --dns=127.0.0.1 \
+  --dns=223.5.5.5 \
   --network=host "
 
  # local tz="`uci get system.@system[0].zonename | sed 's/ /_/g'`"


### PR DESCRIPTION
- 将镜像版本从 v2.2 改为 latest
- 修改容器内配置文件路径从 /data/conf 到 /app/data
- 更换 DNS 服务器从 127.0.0.1 到 223.5.5.5
